### PR TITLE
Update README.md to Reduce Verbiage Redundancy in LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ mvn clean package
 cf push
 ```
 
-### Binding to LLM Models
+### Binding to Large Language Models (LLM's)
 
 1. Create a service instance that provides chat LLM capabilities:
 


### PR DESCRIPTION
Update "LLM Models" to "Large Language Models (LLM's)", as first use to use full name before the LLM acronym, but also, to reduce redundancy (Large Language Model Models).